### PR TITLE
Fix failures in pre-5.10 Perls

### DIFF
--- a/lib/Tk/ObjScanner.pm
+++ b/lib/Tk/ObjScanner.pm
@@ -105,7 +105,7 @@ sub _scan {
 
 sub _isa {
     #return UNIVERSAL::isa(@_);
-    return (reftype($_[0]) // '') eq $_[1] ;
+    return (reftype($_[0]) || '') eq $_[1] ;
 }
 
 sub Populate {


### PR DESCRIPTION
// was introduced in 5.10. It's not needed for retype, though, as it
always returns a non-empty string or undef.
