### PR TITLE
Fix POD error

### DIFF
--- a/bin/data-viewer
+++ b/bin/data-viewer
@@ -108,9 +108,3 @@ JSON object are showed as C<HASH>, which is Perl terminology.
 L<Tk::ObjScanner>
 
 =cut
-
-=cut
-
-
-
-


### PR DESCRIPTION
```
% podchecker bin/data-viewer 
*** ERROR: =cut found outside a pod block.  Skipping to next block. at line 120 in file bin/data-viewer
bin/data-viewer has 1 pod syntax error.
```

Thanks: lintian :)